### PR TITLE
Make Phoenix peer dependency

### DIFF
--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -34,10 +34,12 @@
     "@jumpn/utils-composite": "0.7.0",
     "@jumpn/utils-graphql": "0.6.0",
     "core-js": "2.6.0",
-    "phoenix": "1.4.0",
     "zen-observable": "0.8.11"
   },
   "devDependencies": {
     "nps": "5.9.3"
+  },
+  "peerDependencies": {
+    "phoenix": ">= 1.3 < 2"
   }
 }


### PR DESCRIPTION
This unbounds `absinthe-socket` from Phoenix library version and forces
user to specify their own in their `package.json`.

Close #34
Close #37