### PR TITLE
feat: Added optional inactivity timeout

### DIFF
--- a/packages/socket/src/create.js
+++ b/packages/socket/src/create.js
@@ -77,12 +77,15 @@ const absintheChannelName = "__absinthe__:control";
  *   new PhoenixSocket("ws://localhost:4000/socket")
  * );
  */
-const create = (phoenixSocket: PhoenixSocket): AbsintheSocket => {
+const create = (phoenixSocket: PhoenixSocket, options = {}): AbsintheSocket => {
   const absintheSocket: AbsintheSocket = {
     phoenixSocket,
+    absintheChannelName,
     channel: phoenixSocket.channel(absintheChannelName),
     channelJoinCreated: false,
-    notifiers: []
+    notifiers: [],
+    inactivityTimeout: null,
+    inactivityTimeoutDuration: options.inactivityTimeout || 0
   };
 
   phoenixSocket.onOpen(onConnectionOpen(absintheSocket));

--- a/packages/socket/src/types.js
+++ b/packages/socket/src/types.js
@@ -8,7 +8,10 @@ type AbsintheSocket = {|
   channel: Channel,
   channelJoinCreated: boolean,
   notifiers: Array<Notifier<any>>,
-  phoenixSocket: PhoenixSocket
+  phoenixSocket: PhoenixSocket,
+  absintheChannelName: string,
+  inactivityTimeout: number,
+  inactivityTimeoutDuration: number
 |};
 
 type PushHandler<Response: Object> = {|

--- a/packages/socket/src/updateInactiveTimeout.js
+++ b/packages/socket/src/updateInactiveTimeout.js
@@ -1,0 +1,43 @@
+// @flow
+
+import type {AbsintheSocket} from "./types";
+
+const closeConnection = (absintheSocket: AbsintheSocket) => {
+  absintheSocket.channel.leave();
+  absintheSocket.phoenixSocket.disconnect();
+  absintheSocket.channelJoinCreated = false;
+  absintheSocket.channel = absintheSocket.phoenixSocket.channel(
+    absintheSocket.absintheChannelName
+  );
+  return absintheSocket;
+};
+
+const startInactivityTimeout = (absintheSocket: AbsintheSocket) => {
+  if (
+    !absintheSocket.inactivityTimeout &&
+    absintheSocket.inactivityTimeoutDuration
+  ) {
+    absintheSocket.inactivityTimeout = setTimeout(
+      () => closeConnection(absintheSocket),
+      absintheSocket.inactivityTimeoutDuration
+    );
+  }
+  return absintheSocket;
+};
+
+const cancelInactivityTimeout = (absintheSocket: AbsintheSocket) => {
+  if (absintheSocket.inactivityTimeout) {
+    clearTimeout(absintheSocket.inactivityTimeout);
+    absintheSocket.inactivityTimeout = null;
+  }
+  return absintheSocket;
+};
+
+const updateInactivityTimeout = (absintheSocket: AbsintheSocket) => {
+  if (absintheSocket.notifiers.length === 0) {
+    return startInactivityTimeout(absintheSocket);
+  }
+  return cancelInactivityTimeout(absintheSocket);
+};
+
+export default updateInactivityTimeout;

--- a/packages/socket/src/updateNotifiers.js
+++ b/packages/socket/src/updateNotifiers.js
@@ -1,4 +1,5 @@
 // @flow
+import updateInactiveTimeout from "./updateInactiveTimeout";
 
 import type {AbsintheSocket} from "./types";
 import type {Notifier} from "./notifier/types";
@@ -11,7 +12,7 @@ const updateNotifiers = (
 ) => {
   absintheSocket.notifiers = updater(absintheSocket.notifiers);
 
-  return absintheSocket;
+  return updateInactiveTimeout(absintheSocket);
 };
 
 export default updateNotifiers;


### PR DESCRIPTION
This is inspired by the inactivityTimeout in https://github.com/apollographql/subscriptions-transport-ws. It will automatically close socket connection after a timeout if no subscriptions are active. 

Given that there is no options passed in at the moment when creating a new absintheSocket, I was not sure if this is the best way of doing it. Please let me know if you want me to change this or move the implementation somewhere else.