### PR TITLE
fix request error

### DIFF
--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -27,7 +27,7 @@ const setNotifierRequestStatusSending = (absintheSocket, notifier) =>
     requestStatus: requestStatuses.sending
   });
 
-const createRequestError = message => new Error(`request: ${message}`);
+const createRequestError = message => new Error(message);
 
 const onTimeout = (absintheSocket, notifier) =>
   notifierNotifyActive(


### PR DESCRIPTION
If during apollo subscription an error occurs in the form of an object, then in catch we get request: [Object object]. This hotfix resolves the issue.