### PR TITLE
createRequestError: parse object messages to string

### DIFF
--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -27,7 +27,14 @@ const setNotifierRequestStatusSending = (absintheSocket, notifier) =>
     requestStatus: requestStatuses.sending
   });
 
-const createRequestError = message => new Error(`request: ${message}`);
+const createRequestError = message => {
+  if (String(message) === '[object Object]') {
+    try { 
+      message = JSON.stringify(message, null, 2);
+    } catch (_) {}
+  }
+  return new Error(`request: ${message}`)
+};
 
 const onTimeout = (absintheSocket, notifier) =>
   notifierNotifyActive(


### PR DESCRIPTION
Before, error objects would come out of absinthe sockets as `request [object Object]`.

For example, these sort of GraphQL errors returned via socket:

```
{
  errors: [
    {
      locations: [Array],
      message: 'Fragment spread has no type overlap with parent.\n' +
        'Parent possible types: ["RootSubscriptionType"]\n' +
        'Spread possible types: ["User"]\n'
    }
  ]
}
```

Now, they'll show up as stringified JSON.