### PR TITLE
Relax dependency resolution.

### DIFF
--- a/packages/socket-apollo-link/package.json
+++ b/packages/socket-apollo-link/package.json
@@ -33,14 +33,14 @@
   ],
   "dependencies": {
     "@absinthe/socket": "0.2.1",
-    "@babel/runtime": "7.2.0",
-    "apollo-link": "1.2.5",
-    "core-js": "2.6.0",
-    "flow-static-land": "0.2.8",
-    "graphql": "14.0.2",
-    "zen-observable": "0.8.11"
+    "@babel/runtime": "^7.2.0",
+    "apollo-link": "^1.2.5",
+    "core-js": "^2.6.0",
+    "flow-static-land": "^0.2.8",
+    "graphql": "^14.0.2",
+    "zen-observable": "^0.8.11"
   },
   "devDependencies": {
-    "nps": "5.9.3"
+    "nps": "^5.9.3"
   }
 }


### PR DESCRIPTION
For the resolution of dependencies (especially in the face of TypeScript actually checking) it makes sense to have ambiguous dependency versions set.