### PR TITLE
Attach request error object

### DIFF
--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -27,8 +27,6 @@ const setNotifierRequestStatusSending = (absintheSocket, notifier) =>
     requestStatus: requestStatuses.sending
   });
 
-// const createRequestError = message => new Error(`request: ${message}`);
-
 const createRequestError = message => {
   const error = new Error(`request: ${message}`);
   error.object = message;

--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -27,7 +27,14 @@ const setNotifierRequestStatusSending = (absintheSocket, notifier) =>
     requestStatus: requestStatuses.sending
   });
 
-const createRequestError = message => new Error(`request: ${message}`);
+// const createRequestError = message => new Error(`request: ${message}`);
+
+const createRequestError = message => {
+  const error = new Error(`request: ${message}`);
+  error.object = message;
+
+  return error;
+}
 
 const onTimeout = (absintheSocket, notifier) =>
   notifierNotifyActive(

--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -34,7 +34,7 @@ const createRequestError = message => {
   error.object = message;
 
   return error;
-}
+};
 
 const onTimeout = (absintheSocket, notifier) =>
   notifierNotifyActive(


### PR DESCRIPTION
This PR is for fixing the stringify error object. For majority users like me, the error is not useful because I want to be able to read the object and display a user-friendly error. This PR also make sure to retain the stringify error.

If you need the stringify error, it works the same, just do error.message which gives `request: [Object object]`
If you need the error object, just do `error.object`