### PR TITLE
fix: duplicate subscriptions

### DIFF
--- a/packages/socket/src/joinChannel.js
+++ b/packages/socket/src/joinChannel.js
@@ -19,12 +19,12 @@ const notifyErrorToAllActive = (absintheSocket, errorMessage) =>
 
 // join Push is reused and so the handler
 // https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L356
-const createChannelJoinHandler = absintheSocket => ({
+const createChannelJoinHandler = (absintheSocket, notifiers) => ({
   onError: (errorMessage: string) =>
     notifyErrorToAllActive(absintheSocket, errorMessage),
 
   onSucceed: () =>
-    absintheSocket.notifiers.forEach(notifier =>
+    notifiers.forEach(notifier =>
       pushRequest(absintheSocket, notifier)
     ),
 
@@ -32,9 +32,10 @@ const createChannelJoinHandler = absintheSocket => ({
 });
 
 const joinChannel = (absintheSocket: AbsintheSocket) => {
+  const notifiers = absintheSocket.notifiers
   handlePush(
     absintheSocket.channel.join(),
-    createChannelJoinHandler(absintheSocket)
+    createChannelJoinHandler(absintheSocket, notifiers)
   );
 
   absintheSocket.channelJoinCreated = true;


### PR DESCRIPTION
There is a frame of time between the socket creation and send a request that can cause duplicate subscriptions to prevent that, it is necessary to only call `pushRequest` to `notifiers` that are appended at the moment that the `handPush` is called.