### PR TITLE
Stringify error message in subscription onError

### DIFF
--- a/packages/socket/src/pushRequestUsing.js
+++ b/packages/socket/src/pushRequestUsing.js
@@ -28,7 +28,7 @@ const setNotifierRequestStatusSending = (absintheSocket, notifier) =>
   });
 
 const createRequestError = message => {
-  const error = new Error(`request: ${message}`);
+  const error = new Error(`request: ${JSON.stringify(message)}`);
   error.object = message;
 
   return error;


### PR DESCRIPTION
By default we should show an error that the engineer can immediately understand